### PR TITLE
DS-4683: Update vulnerable packages

### DIFF
--- a/restore/Dockerfile
+++ b/restore/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.15
 LABEL maintainer="Praveen Perera <praveen@avencera.com>"
 
-## Install AWS CLI
+RUN apk update
+
 # install pg_dump and python
 RUN apk add --no-cache postgresql-client \
     python3 \


### PR DESCRIPTION
**What this PR does / why we need it**:
- A number of packages are vulnerable (see screenshot below)
- This is probably because the `restore/Dockerfile` does not `RUN apk update` before installing the dependencies
- Running it inside a container shows that all the vulnerable packages are updated to at least the recommended fix level:
```shell
$ docker run --rm -it --entrypoint /bin/sh docker.io/portworx/postgres-backup-restore:dev-697b5fd-2207181018
/ # apk update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
v3.15.7-14-gcfb0d81afed [https://dl-cdn.alpinelinux.org/alpine/v3.15/main]
v3.15.7-13-gd738a42a973 [https://dl-cdn.alpinelinux.org/alpine/v3.15/community]
OK: 15870 distinct packages available
/ # apk -s upgrade
(1/13) Upgrading busybox (1.34.1-r5 -> 1.34.1-r7)
(2/13) Upgrading ca-certificates-bundle (20211220-r0 -> 20220614-r0)
(3/13) Upgrading libcrypto1.1 (1.1.1n-r0 -> 1.1.1t-r1)
(4/13) Upgrading libssl1.1 (1.1.1n-r0 -> 1.1.1t-r1)
(5/13) Upgrading ssl_client (1.34.1-r5 -> 1.34.1-r7)
(6/13) Upgrading zlib (1.2.12-r0 -> 1.2.12-r3)
(7/13) Upgrading postgresql-common (1.1-r0 -> 1.1-r1)
(8/13) Upgrading libpq (14.4-r0 -> 14.7-r0)
(9/13) Upgrading ncurses-terminfo-base (6.3_p20211120-r0 -> 6.3_p20211120-r1)
(10/13) Upgrading ncurses-libs (6.3_p20211120-r0 -> 6.3_p20211120-r1)
(11/13) Upgrading postgresql14-client (14.4-r0 -> 14.7-r0)
(12/13) Upgrading expat (2.4.7-r0 -> 2.5.0-r0)
(13/13) Upgrading python3 (3.9.7-r4 -> 3.9.16-r0)
OK: 79 MiB in 57 packages
/ # 
```

**Which issue(s) this PR fixes** (optional)
[Jira DS-4683](https://portworx.atlassian.net/browse/DS-4683)

**Screenshot of vulnerabilities table**
![image](https://user-images.githubusercontent.com/86960833/220078505-56cf1e0e-cfb7-4749-94fc-6b3477360f8b.png)